### PR TITLE
feat: add security scan

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -89,4 +89,4 @@ jobs:
           file: ${{ inputs.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ inputs.image-name }}:${{ github.sha }}
+          tags: ${{ inputs.image-name }}:${{ github.ref_name }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Build, Test and Push Docker Image
 
 on:
   workflow_call:
@@ -18,50 +18,60 @@ on:
         required: true
 
 jobs:
-  build-and-push:
+  build-test:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    env:
-      IS_TAG_TRIGGER: ${{ startsWith(github.ref, 'refs/tags/v') }}
     steps:
-      - name: Get branch names
-        id: branch-names
-        uses: tj-actions/branch-names@v8
-
-      # Verify tag is on main or release branch
-      - name: Verify tag is on main or release branch
-        if: env.IS_TAG_TRIGGER == 'true'
-        run: |
-          if [[ "${{ steps.branch-names.outputs.base_ref_branch }}" == "main" || "${{ steps.branch-names.outputs.base_ref_branch }}" =~ ^release/ ]]; then
-            echo "✅ Tag ${{ steps.branch-names.outputs.tag }} is on an allowed branch: ${{ steps.branch-names.outputs.base_ref_branch }}"
-          else
-            echo "Current base branch: ${{ steps.branch-names.outputs.base_ref_branch }}"
-            echo "Tags must be created on main or release/* branches."
-            exit 1
-
-      - name: Verify npm package version matches tag
-        if: env.IS_TAG_TRIGGER == 'true'
-        uses: nick-y-ito/gha-npm-version-match@v1
-
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      # Determine Docker Image Tags
-      - name: Determine Docker Image Tags
-        run: |
-          IMAGE_NAME="${{ inputs.image-name }}"
-          # Initialize IMAGE_TAG variable
-          IMAGE_TAG=""
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-          if [[ "$IS_TAG_TRIGGER" == "true" ]]; then
-            TAG_VERSION=${GITHUB_REF#refs/tags/v}
-            IMAGE_TAG="$IMAGE_NAME:$TAG_VERSION"
-          else
-            SHORT_COMMIT=$(git rev-parse --short HEAD)
-            IMAGE_TAG="$IMAGE_NAME:dev-$SHORT_COMMIT"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ inputs.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ${{ inputs.image-name }}:${{ github.sha }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.29.0
+        with:
+          image-ref: ${{ inputs.image-name }}:${{ github.sha }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          hide-progress: true
+          output: trivy.txt
+
+      - name: Publish Trivy Output to Summary
+        run: |
+          if [[ -s trivy.txt ]]; then
+            {
+              echo "### Security Output"
+              echo "<details><summary>Click to expand</summary>"
+              echo ""
+              echo '```terraform'
+              cat trivy.txt
+              echo '```'
+              echo "</details>"
+            } >> $GITHUB_STEP_SUMMARY
           fi
 
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-          echo "✅ Resolved IMAGE_TAG: $IMAGE_TAG"
+  build-push:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -69,16 +79,14 @@ jobs:
           username: ${{ secrets.dockerhub-username }}
           password: ${{ secrets.dockerhub-pat }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and Push Docker Image
+      - name: Push Docker Image
         uses: docker/build-push-action@v6
         with:
+          context: .
           file: ${{ inputs.dockerfile }}
-          push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ env.IMAGE_TAG }}
+          push: true
+          tags: ${{ inputs.image-name }}:${{ github.sha }}


### PR DESCRIPTION
This pull request includes significant updates to the `.github/workflows/docker-build.yml` file to enhance the CI/CD pipeline by adding testing and security scanning steps, and by improving the organization of the workflow.

Enhancements to CI/CD pipeline:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L1-R1): Renamed the job from `build-and-push` to `build-test` and added a conditional to run only on pull requests. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L1-R1) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L21-R92)
* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L21-R92): Added steps to set up Docker Buildx and QEMU for cross-platform builds.
* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L21-R92): Introduced a new step to run the Trivy vulnerability scanner on the Docker image and publish the output to the GitHub summary.
* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L21-R92): Created a separate `build-push` job to handle pushing the Docker image, triggered only on tag pushes.
* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L21-R92): Simplified the Docker image tagging process by removing the manual tag verification and using GitHub SHA for tagging.