### PR TITLE
feat(docker-build): add hadolint and fix trivy

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Build Docker Image as Tarball
         if: ${{ inputs.security-scan }}
         run: |
-          docker build -t ${{ inputs.image-name }}:${{ inputs.image-tag }} -f ${{ inputs.dockerfile }} .
+          docker build -t ${{ inputs.image-name }}:${{ inputs.image-tag }} -f ${{ inputs.dockerfile }} ${{ inputs.context }}
           docker save -o vuln-image.tar ${{ inputs.image-name }}:${{ inputs.image-tag }}
 
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,10 +27,14 @@ on:
         description: 'Push Docker Image to Registry'
         default: false
         type: boolean
+      registry:
+        description: 'Docker Registry'
+        default: 'docker.io'
+        type: string
     secrets:
-      dockerhub-username:
+      username:
         required: false
-      dockerhub-pat:
+      password:
         required: false
 
 jobs:
@@ -50,8 +54,9 @@ jobs:
         if: ${{ inputs.push }}
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.dockerhub-username }}
-          password: ${{ secrets.dockerhub-pat }}
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.username }}
+          password: ${{ secrets.password }}
 
       - name: Run Hadolint Dockerfile linter
         if: ${{ inputs.hadolint }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,17 +17,21 @@ on:
         required: true
       security-scan:
         description: 'Enable Security Scan'
-        default: 'true'
+        default: true
+        type: boolean
+      hadolint:
+        description: 'Enable Hadolint'
+        default: true
         type: boolean
       push:
         description: 'Push Docker Image to Registry'
-        default: 'false'
+        default: false
         type: boolean
     secrets:
       dockerhub-username:
-        required: true
+        required: false
       dockerhub-pat:
-        required: true
+        required: false
 
 jobs:
   build:
@@ -42,7 +46,23 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      - name: Login to Docker Hub
+        if: ${{ inputs.push }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.dockerhub-username }}
+          password: ${{ secrets.dockerhub-pat }}
+
+      - name: Run Hadolint Dockerfile linter
+        if: ${{ inputs.hadolint }}
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ${{ inputs.dockerfile }}
+          output-file: hadolint.txt
+          no-fail: true
+
       - name: Build Docker Image
+        if: ${{ inputs.push }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -51,30 +71,72 @@ jobs:
           push: ${{ inputs.push }}
           tags: ${{ inputs.image-name }}:${{ inputs.image-tag }}
 
+      - name: Build Docker Image as Tarball
+        if: ${{ inputs.security-scan }}
+        run: |
+          docker build -t ${{ inputs.image-name }}:${{ inputs.image-tag }} -f ${{ inputs.dockerfile }} .
+          docker save -o vuln-image.tar ${{ inputs.image-name }}:${{ inputs.image-tag }}
+
       - name: Run Trivy vulnerability scanner
         if: ${{ inputs.security-scan }}
         uses: aquasecurity/trivy-action@0.29.0
         with:
-          image-ref: ${{ inputs.image-name }}:${{ inputs.image-tag }}
+          input: vuln-image.tar
           format: 'table'
-          exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
           hide-progress: true
           output: trivy.txt
 
-      - name: Publish Trivy Output to Summary
-        if: ${{ inputs.security-scan }}
-        run: |
-          if [[ -s trivy.txt ]]; then
-            {
-              echo "### Security Output"
-              echo "<details><summary>Click to expand</summary>"
-              echo ""
-              echo '```terraform'
-              cat trivy.txt
-              echo '```'
-              echo "</details>"
-            } >> $GITHUB_STEP_SUMMARY
-          fi
+      - name: Update Pull Request with Security Scan Results
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request' && inputs.security-scan
+        with:
+          script: |
+            const fs = require('fs');
+            const trivyResults = fs.readFileSync('trivy.txt', 'utf8');
+      
+            const output = `
+            ### 🔒 Trivy Security Scan Results
+            <details><summary>Click to expand detailed results</summary>
+      
+            \`\`\`
+            ${trivyResults}
+            \`\`\`
+            </details>
+            `;
+      
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });
+
+      - name: Update Pull Request with Hadolint Results
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request' && inputs.hadolint
+        with:
+          script: |
+            const fs = require('fs');
+            const hadolintResults = fs.readFileSync('hadolint.txt', 'utf8').trim();
+            
+            if (hadolintResults.length > 0) {
+              const output = `
+              ### 🐳 Hadolint Dockerfile Lint Results
+              <details><summary>Click to expand</summary>
+            
+              \`\`\`
+              ${hadolintResults}
+              \`\`\`
+              </details>
+              `;
+
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              });
+            }

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,6 +27,10 @@ on:
         description: 'Push Docker Image to Registry'
         default: false
         type: boolean
+      context:
+        description: 'Path to Docker Build Context'
+        default: '.'
+        type: string
       registry:
         description: 'Docker Registry'
         default: 'docker.io'
@@ -70,7 +74,7 @@ jobs:
         if: ${{ inputs.push }}
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: ${{ inputs.push }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building Docker images. The changes introduce new options for linting Dockerfiles with Hadolint, improve the security scan process, and enhance the handling of secrets for Docker Hub login.

Key changes include:

### Workflow Enhancements:
* Added a new input option to enable Hadolint linting for Dockerfiles (`.github/workflows/docker-build.yml`).
* Added steps to login to Docker Hub and run Hadolint if the respective inputs are enabled (`.github/workflows/docker-build.yml`).

### Security Improvements:
* Modified the security scan process to build the Docker image as a tarball before scanning with Trivy (`.github/workflows/docker-build.yml`).
* Updated the workflow to post security scan results and Hadolint results as comments on the pull request (`.github/workflows/docker-build.yml`).

### Secret Handling:
* Changed the required status of Docker Hub secrets to optional (`.github/workflows/docker-build.yml`).