### PR TITLE
fix(npm): change install command

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -29,7 +29,7 @@ on:
       install-command:
         description: 'Command to install dependencies'
         required: false
-        default: 'npm install'
+        default: 'npm ci'
         type: string
       environment:
         description: 'GitHub environment to use for deployment'


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish-npm.yml` file. The change updates the default command for installing dependencies from `npm install` to `npm ci`.

* [`.github/workflows/publish-npm.yml`](diffhunk://#diff-f089b0e55b389f533faf1e65e3cb93b0bcd97b391c32f28449d08fd4f0512447L32-R32): Changed the default `install-command` from `npm install` to `npm ci` to ensure a clean and consistent installation of dependencies.