### PR TITLE
docs(npm): fix secret file

### DIFF
--- a/publish-npm/README.md
+++ b/publish-npm/README.md
@@ -76,7 +76,7 @@ This reusable GitHub Actions workflow automates the process of publishing an NPM
          node-version: '20'
          registry-url: 'https://registry.npmjs.org'
        secrets:
-         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+         npm-token: ${{ secrets.NPM_TOKEN }}
    ```
 
 3. **Configure Secrets:**  


### PR DESCRIPTION
This pull request includes a small change to the `publish-npm/README.md` file. The change corrects the case of the `NPM_TOKEN` secret to `npm-token` to ensure consistency with the rest of the documentation.

* [`publish-npm/README.md`](diffhunk://#diff-8e43c2c899472a243a7eb921d273e3cc0717a62ae2641a0c397d6919f2d325fbL79-R79): Changed `NPM_TOKEN` to `npm-token` in the GitHub Actions workflow example.