### PR TITLE
feat(npm): add tag

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -36,6 +36,11 @@ on:
         required: false
         default: 'production'
         type: string
+      tag:
+        description: 'NPM publish tag (e.g., latest, nightly)'
+        required: false
+        default: ''
+        type: string
     secrets:
       npm-token:
         description: 'NPM token for authentication'
@@ -63,10 +68,15 @@ jobs:
 
       - name: Publish package
         run: |
+          TAG_OPTION=""
+          if [ -n "${{ inputs.tag }}" ]; then
+            TAG_OPTION="--tag ${{ inputs.tag }}"
+          fi
+
           if [ "${{ inputs.provenance }}" = "true" ]; then
-            npm publish --access ${{ inputs.access }} --provenance
+            npm publish --access ${{ inputs.access }} $TAG_OPTION --provenance
           else
-            npm publish --access ${{ inputs.access }}
+            npm publish --access ${{ inputs.access }} $TAG_OPTION
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/publish-npm.yml` file to enhance the flexibility of the NPM publish process. The most important changes include the addition of a new input parameter for specifying an NPM publish tag and the corresponding logic to handle this new parameter during the publish step.

Enhancements to NPM publish workflow:

* [`.github/workflows/publish-npm.yml`](diffhunk://#diff-f089b0e55b389f533faf1e65e3cb93b0bcd97b391c32f28449d08fd4f0512447R39-R43): Added a new input parameter `tag` to allow specifying an NPM publish tag (e.g., latest, nightly).
* [`.github/workflows/publish-npm.yml`](diffhunk://#diff-f089b0e55b389f533faf1e65e3cb93b0bcd97b391c32f28449d08fd4f0512447R71-R79): Updated the publish step to include the `tag` parameter in the `npm publish` command if it is provided.