### PR TITLE
fix(release-please): add issues permission

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release-please.yml` file. The change grants write permissions to issues.

* [`.github/workflows/release-please.yml`](diffhunk://#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3R13): Added `issues: write` under `permissions`.