### PR TITLE
ci(release): use dynamic token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,18 @@ jobs:
       matrix:
         package: ${{ fromJSON(needs.setup-release-context.outputs.packages) }}
     steps:
+      - name: Get Token
+        id: get_token
+        uses: peter-murray/workflow-application-token-action@v4
+        with:
+          application_id: "${{ secrets.RELEASE_PLEASE_APPLICATION_ID }}"
+          application_private_key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+          organization: ${{ github.repository_owner }}
       - uses: googleapis/release-please-action@v3
         id: release
         with:
           default-branch: main
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.get_token.outputs.token }}
           release-type: simple
           package-name: ${{ matrix.package }}
           version-file: ${{ matrix.package }}/version.txt


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release.yml` to enhance security and token management. The most notable change is the replacement of a static secret-based token with a dynamically generated application token.

### Workflow improvements:

* Added a new step, `Get Token`, to dynamically generate an application token using the `peter-murray/workflow-application-token-action@v4` action. This step improves security by replacing the static `RELEASE_PLEASE_TOKEN` secret with a token generated at runtime.
* Updated the `googleapis/release-please-action@v3` step to use the dynamically generated token (`steps.get_token.outputs.token`) instead of the static secret.