### PR TITLE
feat(docker-build): add security report option and upload step

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,10 @@ on:
         description: 'Enable Security Scan'
         default: true
         type: boolean
+      security-report:
+        description: 'Enable Security Report'
+        default: 'sarif'
+        type: string
       hadolint:
         description: 'Enable Hadolint'
         default: true
@@ -100,7 +104,7 @@ jobs:
 
       - name: Update Pull Request with Security Scan Results
         uses: actions/github-script@v7
-        if: github.event_name == 'pull_request' && inputs.security-scan
+        if: github.event_name == 'pull_request' && inputs.security-scan && inputs.security-report == 'comment'
         with:
           script: |
             const fs = require('fs');
@@ -122,6 +126,12 @@ jobs:
               repo: context.repo.repo,
               body: output
             });
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: github.event_name == 'pull_request' && inputs.security-scan && inputs.security-report == 'sarif'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
 
       - name: Update Pull Request with Hadolint Results
         uses: actions/github-script@v7


### PR DESCRIPTION
This pull request updates the `.github/workflows/docker-build.yml` file to enhance security reporting capabilities by introducing a new input parameter and associated actions. The most important changes include adding support for a `security-report` input, modifying conditions for existing steps, and introducing a new step to upload SARIF files to GitHub's Security tab.

### Enhancements to security reporting:

* Added a new `security-report` input parameter with a default value of `'sarif'` and type `string`. This allows users to specify the desired format for security scan results. (`[.github/workflows/docker-build.ymlR22-R25](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R22-R25)`)
* Updated the condition for the "Update Pull Request with Security Scan Results" step to check for `security-report == 'comment'` in addition to the existing conditions. (`[.github/workflows/docker-build.ymlL103-R107](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L103-R107)`)
* Introduced a new step to upload Trivy scan results in SARIF format to GitHub's Security tab when `security-report == 'sarif'`. This step uses the `github/codeql-action/upload-sarif@v3` action. (`[.github/workflows/docker-build.ymlR130-R135](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R130-R135)`)