### PR TITLE
feat(release-please): add target branch configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,3 +28,4 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ steps.get_token.outputs.token }}
+          target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
This pull request makes a small update to the `.github/workflows/release-please.yml` file. The change adds a `target-branch` input to the `release-please-action` configuration, dynamically setting it to the current branch name.