### PR TITLE
feat(rust-build): add reusable workflow

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -1,0 +1,103 @@
+name: Build, Test and Publish Rust Package
+
+on:
+  workflow_call:
+    inputs:
+      rust-version:
+        description: 'Rust version to use'
+        default: 'stable'
+        type: string
+      build-target:
+        description: 'Cargo profile to use for building (debug, release)'
+        default: 'release'
+        type: string
+      enable-cache:
+        description: 'Enable caching of dependencies'
+        default: true
+        type: boolean
+      publish-crates-io:
+        description: 'Publish package to crates.io'
+        default: false
+        type: boolean
+      upload-artifact:
+        description: 'Upload build artifact'
+        default: false
+        type: boolean
+      artifact-name:
+        description: 'Name of the artifact to upload'
+        type: string
+        required: false
+      artifact-path:
+        description: 'Path to the artifact to upload'
+        type: string
+        required: false
+    secrets:
+      CRATES_IO_TOKEN:
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      build_success: ${{ steps.set-output.outputs.build_success }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ inputs.rust-version }}
+          override: true
+
+      - name: Cache dependencies
+        if: ${{ inputs.enable-cache }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build
+        run: cargo build --profile ${{ inputs.build-target }}
+
+      - name: Run tests
+        run: cargo test --profile ${{ inputs.build-target }}
+
+      - name: Set build success output
+        id: set-output
+        run: echo "build_success=true" >> $GITHUB_OUTPUT
+
+      - name: Upload artifact
+        if: ${{ inputs.upload-artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
+
+  publish:
+    needs: build
+    if: ${{ inputs.publish-crates-io && needs.build.outputs.build_success == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ inputs.rust-version }}
+          override: true
+
+      - name: Login to crates.io
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+
+      - name: Package for crates.io
+        run: cargo package
+
+      - name: Publish to crates.io
+        run: cargo publish

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -1,0 +1,87 @@
+# Rust Build Workflow
+
+A reusable GitHub Actions workflow for building, testing, and publishing Rust packages.
+
+## Features
+
+- Build and test Rust packages
+- Cache dependencies for faster builds
+- Publish packages to crates.io
+- Upload build artifacts
+
+## Usage
+
+```yaml
+name: Rust CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    uses: your-org/github-actions-workflows/.github/workflows/rust-build.yml@main
+    with:
+      rust-version: 'stable'
+      build-target: 'release'
+      enable-cache: true
+      upload-artifact: true
+      artifact-name: 'my-rust-app'
+      artifact-path: 'target/release/my-app'
+    secrets:
+      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+```
+
+## Inputs
+
+| Name                | Description                                        | Default   | Required                            |
+|---------------------|----------------------------------------------------|-----------|-------------------------------------|
+| `rust-version`      | Rust version to use                                | `stable`  | No                                  |
+| `build-target`      | Cargo profile to use for building (debug, release) | `release` | No                                  |
+| `enable-cache`      | Enable caching of dependencies                     | `true`    | No                                  |
+| `publish-crates-io` | Publish package to crates.io                       | `false`   | No                                  |
+| `upload-artifact`   | Upload build artifact                              | `false`   | No                                  |
+| `artifact-name`     | Name of the artifact to upload                     | -         | Only if `upload-artifact` is `true` |
+| `artifact-path`     | Path to the artifact to upload                     | -         | Only if `upload-artifact` is `true` |
+
+## Secrets
+
+| Name              | Description                       | Required                              |
+|-------------------|-----------------------------------|---------------------------------------|
+| `CRATES_IO_TOKEN` | Token for publishing to crates.io | Only if `publish-crates-io` is `true` |
+
+## Examples
+
+### Basic Build and Test
+
+```yaml
+jobs:
+  build-and-test:
+    uses: your-org/github-actions-workflows/.github/workflows/rust-build.yml@main
+```
+
+### Build, Test, and Upload Artifact
+
+```yaml
+jobs:
+  build-and-test:
+    uses: your-org/github-actions-workflows/.github/workflows/rust-build.yml@main
+    with:
+      upload-artifact: true
+      artifact-name: 'my-rust-app'
+      artifact-path: 'target/release/my-app'
+```
+
+### Build, Test, and Publish to crates.io
+
+```yaml
+jobs:
+  build-and-publish:
+    uses: your-org/github-actions-workflows/.github/workflows/rust-build.yml@main
+    with:
+      publish-crates-io: true
+    secrets:
+      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+```

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -14,15 +14,11 @@ A reusable GitHub Actions workflow for building, testing, and publishing Rust pa
 ```yaml
 name: Rust CI
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [pull_request]
 
 jobs:
   build-and-test:
-    uses: your-org/github-actions-workflows/.github/workflows/rust-build.yml@main
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       rust-version: 'stable'
       build-target: 'release'
@@ -30,8 +26,6 @@ jobs:
       upload-artifact: true
       artifact-name: 'my-rust-app'
       artifact-path: 'target/release/my-app'
-    secrets:
-      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 ```
 
 ## Inputs
@@ -59,7 +53,7 @@ jobs:
 ```yaml
 jobs:
   build-and-test:
-    uses: your-org/github-actions-workflows/.github/workflows/rust-build.yml@main
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
 ```
 
 ### Build, Test, and Upload Artifact
@@ -67,7 +61,7 @@ jobs:
 ```yaml
 jobs:
   build-and-test:
-    uses: your-org/github-actions-workflows/.github/workflows/rust-build.yml@main
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       upload-artifact: true
       artifact-name: 'my-rust-app'
@@ -79,7 +73,7 @@ jobs:
 ```yaml
 jobs:
   build-and-publish:
-    uses: your-org/github-actions-workflows/.github/workflows/rust-build.yml@main
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       publish-crates-io: true
     secrets:


### PR DESCRIPTION
This pull request introduces a reusable GitHub Actions workflow for building, testing, and publishing Rust packages. It also includes comprehensive documentation to guide users on how to utilize the workflow effectively.

### New GitHub Actions Workflow for Rust (`.github/workflows/rust-build.yml`):
* Added a reusable workflow to build, test, and optionally publish Rust packages to crates.io. It supports features such as dependency caching, artifact uploading, and configurable Rust versions and build profiles.

### Documentation (`rust-build/README.md`):
* Created a detailed `README.md` file explaining the workflow's features, inputs, secrets, and usage examples, including configurations for basic builds, artifact uploads, and publishing to crates.io.