### PR TITLE
feat(conventional-commits): validate PR titles

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,15 +1,18 @@
-name: Conventional Commits
+name: "Lint PR"
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
 
 jobs:
-  build:
-    name: Conventional Commits
+  validate-pr-title:
+    name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: webiny/action-conventional-commits@v1.3.0
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ This workflow uses the [release-please-action](https://github.com/googleapis/rel
 
 ### [Publish NPM Package](./publish-npm)
 This workflow publishes an NPM package to the NPM registry.
+
+### [Conventional Commits](./conventional-commits)
+This workflow checks that pull request titles follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.

--- a/conventional-commits/README.md
+++ b/conventional-commits/README.md
@@ -1,0 +1,28 @@
+# Conventional Commits
+
+This workflow checks that pull request titles follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+## Secrets
+
+### `GITHUB_TOKEN`
+
+**Required** The GitHub token to use for authentication.
+
+## Example usage
+
+```yaml
+name: Lint PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  lint-pr-title:
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/conventional-commits.yaml@conventional-commits-v1.0.0
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to validate pull request titles against the Conventional Commits specification. The changes include renaming and updating the workflow file, adding documentation for the new workflow, and providing an example usage.

### Workflow updates:

* [`.github/workflows/conventional-commits.yaml`](diffhunk://#diff-a6050080912e835914230cb5a27547ae7204f3af057fb775cbb0ea1830e3c251L1-R18): Renamed the workflow to "Lint PR" and updated it to validate pull request titles using the `amannn/action-semantic-pull-request` action. The workflow now uses `workflow_call` with a required `GITHUB_TOKEN` secret for authentication.

### Documentation additions:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R17): Added a section linking to the new "Conventional Commits" workflow and explaining its purpose.
* [`conventional-commits/README.md`](diffhunk://#diff-05cfabc4106bc5ca03b97c0f732b0fb0abeaceb393de4c92db55bf4a8231e20bR1-R28): Created a new README file detailing the workflow, its required secrets, and an example usage configuration.