### PR TITLE
fix(conventional-commits): remove reserved name secret

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -2,9 +2,6 @@ name: "Lint PR"
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   validate-pr-title:


### PR DESCRIPTION
This pull request removes unnecessary `secrets` configuration from the `Lint PR` workflow in the `.github/workflows/conventional-commits.yml` file. The `GITHUB_TOKEN` secret is no longer required for this workflow.