### PR TITLE
feat(conventional-commits): add sticky comments for PR title linting

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -13,3 +13,27 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
This pull request updates the `.github/workflows/conventional-commits.yml` file to improve the handling of pull request title validation errors. It introduces a mechanism to provide feedback to contributors when their pull request titles do not conform to the Conventional Commits specification.

### Workflow Enhancements:
* Added the `marocchino/sticky-pull-request-comment@v2` action to post a detailed comment on pull requests when the title validation fails, providing guidance on how to fix the issue.
* Configured the workflow to delete the comment once the title issue has been resolved, ensuring the feedback is kept up-to-date and relevant.