### PR TITLE
feat(npm): add workdirectory

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -42,6 +42,10 @@ on:
         required: false
         default: ''
         type: string
+      working-directory:
+        description: "Change the workspace"
+        default: ''
+        type: string
     secrets:
       npm-token:
         description: 'NPM token for authentication'
@@ -65,9 +69,11 @@ jobs:
           scope: ${{ inputs.scope }}
 
       - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
         run: ${{ inputs.install-command }}
 
       - name: Publish package
+        working-directory: ${{ inputs.working-directory }}
         run: |
           TAG_OPTION=""
           if [ -n "${{ inputs.tag }}" ]; then


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish-npm.yml` file to add support for specifying a working directory for the workflow. This enhancement allows the workflow to be more flexible when handling projects with different directory structures.

### Workflow Enhancements:

* Added a new input parameter, `working-directory`, to allow users to specify a custom workspace directory in the workflow.
* Updated the `Install dependencies` and `Publish package` steps to use the specified `working-directory` input, ensuring commands are executed in the correct directory.