### PR TITLE
feat(sconify)!: move usernames to secret and ouput tags

### DIFF
--- a/.github/workflows/sconify.yml
+++ b/.github/workflows/sconify.yml
@@ -7,20 +7,12 @@ on:
         description: "Docker registry of docker image to sconify"
         default: "docker.io"
         type: string
-      docker-username:
-        description: "Docker registry username"
-        type: string
-        required: true
       image-name:
         description: "Name of docker image to sconify"
         type: string
         required: true
       image-tag:
         description: "Tag of docker image to sconify"
-        type: string
-        required: true
-      scontain-username:
-        description: "Scontain registry username"
         type: string
         required: true
       sconify-version:
@@ -72,8 +64,14 @@ on:
         type: string
         default: "ubuntu-latest"
     secrets:
+      docker-username:
+        description: "Docker registry username"
+        required: true
       docker-password:
         description: "Docker Registry Password or Token"
+        required: true
+      scontain-username:
+        description: "Scontain registry username"
         required: true
       scontain-password:
         description: "Scontain Registry Password or Token"
@@ -161,14 +159,14 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.docker-registry }}
-          username: ${{ inputs.docker-username }}
+          username: ${{ secrets.docker-username }}
           password: ${{ secrets.docker-password }}
 
       - name: Login to Scontain Docker Registry
         uses: docker/login-action@v3
         with:
           registry: "registry.scontain.com"
-          username: ${{ inputs.scontain-username }}
+          username: ${{ secrets.scontain-username }}
           password: ${{ secrets.scontain-password }}
 
       - name: Pull Image to Sconify

--- a/.github/workflows/sconify.yml
+++ b/.github/workflows/sconify.yml
@@ -80,18 +80,18 @@ on:
         description: "Signing Key for Scone Production (not required with `sconify-prod: false`)"
         required: false
     outputs:
-      debug-image:
-        description: "Debug Sconified Image"
-        value: ${{ jobs.build.outputs.debug-image }}
+      debug-image-tag:
+        description: "Debug Sconified Image Tag"
+        value: ${{ jobs.build.outputs.debug-image-tag }}
       debug-mrenclave:
         description: "Debug Sconified Image MrEnclave Fingerprint"
         value: ${{ jobs.build.outputs.debug-mrenclave }}
       debug-checksum:
         description: "Debug Sconified Image Checksum"
         value: ${{ jobs.build.outputs.debug-checksum }}
-      prod-image:
-        description: "Prod Sconified Image"
-        value: ${{ jobs.build.outputs.prod-image }}
+      prod-image-tag:
+        description: "Prod Sconified Image Tag"
+        value: ${{ jobs.build.outputs.prod-image-tag }}
       prod-mrenclave:
         description: "Prod Sconified Image MrEnclave Fingerprint"
         value: ${{ jobs.build.outputs.prod-mrenclave }}
@@ -103,10 +103,10 @@ jobs:
   build:
     runs-on: ${{ inputs.runner }}
     outputs:
-      debug-image: ${{ steps.push-debug.outputs.image }}
+      debug-image-tag: ${{ steps.push-debug.outputs.tag }}
       debug-mrenclave: ${{ steps.push-debug.outputs.mrenclave }}
       debug-checksum: ${{ steps.push-debug.outputs.checksum }}
-      prod-image: ${{ steps.push-prod.outputs.image }}
+      prod-image-tag: ${{ steps.push-prod.outputs.tag }}
       prod-mrenclave: ${{ steps.push-prod.outputs.mrenclave }}
       prod-checksum: ${{ steps.push-prod.outputs.checksum }}
     steps:
@@ -116,17 +116,19 @@ jobs:
       - name: Prepare Sconify Command
         id: prepare-command
         run: |
-          FROM_IMAGE=${{ inputs.docker-registry }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
-          DEBUG_IMAGE=$FROM_IMAGE-scone-debug-${{ inputs.sconify-version }}
-          echo "debug-image=$DEBUG_IMAGE"
-          echo "debug-image=$DEBUG_IMAGE" >> "$GITHUB_OUTPUT"
-          PROD_IMAGE=$FROM_IMAGE-scone-prod-${{ inputs.sconify-version }}
-          echo "prod-image=$PROD_IMAGE"
-          echo "prod-image=$PROD_IMAGE" >> "$GITHUB_OUTPUT"
+          IMAGE_REPO=${{ inputs.docker-registry }}/${{ inputs.image-name }}
+          DEBUG_IMAGE_TAG=${{ inputs.image-tag }}-scone-debug-${{ inputs.sconify-version }}
+          PROD_IMAGE_TAG=${{ inputs.image-tag }}-scone-prod-${{ inputs.sconify-version }}
+
+          echo "image-repo=$IMAGE_REPO" | tee -a "$GITHUB_OUTPUT"
+          echo "debug-image-tag=$DEBUG_IMAGE_TAG" | tee -a "$GITHUB_OUTPUT"
+          echo "prod-image-tag=$PROD_IMAGE_TAG" | tee -a "$GITHUB_OUTPUT"
+
+          # Prepare the base command for sconify
           SCONIFY_CMD="sconify_iexec"
           # REQUIRED:
           # --from
-          SCONIFY_CMD+=" --from=$FROM_IMAGE"
+          SCONIFY_CMD+=" --from=$IMAGE_REPO:${{ inputs.image-tag }}"
           # --to will be added later on
           # --binary
           SCONIFY_CMD+=" --binary=${{ inputs.binary }}"
@@ -152,8 +154,8 @@ jobs:
           # DEBUG
           # --verbose --no-color options
           SCONIFY_CMD+=" --verbose --no-color"
-          echo "sconify-base-command=$SCONIFY_CMD"
-          echo "sconify-base-command=$SCONIFY_CMD" >> "$GITHUB_OUTPUT"
+
+          echo "sconify-base-command=$SCONIFY_CMD" | tee -a "$GITHUB_OUTPUT"
 
       - name: Login to Docker Registry
         uses: docker/login-action@v3
@@ -183,16 +185,16 @@ jobs:
           -v /var/run/docker.sock:/var/run/docker.sock \
           registry.scontain.com/scone-production/iexec-sconify-image:${{ inputs.sconify-version }} \
           ${{ steps.prepare-command.outputs.sconify-base-command }} \
-          --to=${{ steps.prepare-command.outputs.debug-image }}
+          --to=${{ steps.prepare-command.outputs.image-repo }}:${{ steps.prepare-command.outputs.debug-image-tag }}
 
       - name: Push Debug Image
         if: ${{ inputs.sconify-debug }}
         id: push-debug
         run: |
-          docker push ${{ steps.prepare-command.outputs.debug-image }}
-          echo "image=${{ steps.prepare-command.outputs.debug-image }}" >> "$GITHUB_OUTPUT"
-          echo "checksum=0x$(docker image inspect ${{ steps.prepare-command.outputs.debug-image }} | jq .[0].RepoDigests[0] | sed 's/"//g' | awk -F '@sha256:' '{print $2}')" >> "$GITHUB_OUTPUT"
-          echo "mrenclave=$(docker run --rm -e SCONE_HASH=1 ${{ steps.prepare-command.outputs.debug-image }})" >> "$GITHUB_OUTPUT"
+          docker push ${{ steps.prepare-command.outputs.image-repo }}:${{ steps.prepare-command.outputs.debug-image-tag }}
+          echo "tag=${{ steps.prepare-command.outputs.debug-image-tag }}" | tee -a "$GITHUB_OUTPUT"
+          echo "checksum=0x$(docker image inspect ${{ steps.prepare-command.outputs.image-repo }}:${{ steps.prepare-command.outputs.debug-image-tag }} | jq .[0].RepoDigests[0] | sed 's/"//g' | awk -F '@sha256:' '{print $2}')" | tee -a "$GITHUB_OUTPUT"
+          echo "mrenclave=$(docker run --rm -e SCONE_HASH=1 ${{ steps.prepare-command.outputs.image-repo }}:${{ steps.prepare-command.outputs.debug-image-tag }})" | tee -a "$GITHUB_OUTPUT"
 
       - name: Sconify Image Prod
         if: ${{ inputs.sconify-prod }}
@@ -205,17 +207,17 @@ jobs:
           -v ${{github.workspace}}/tmp/sig/enclave-key.pem:/sig/enclave-key.pem \
           registry.scontain.com/scone-production/iexec-sconify-image:${{ inputs.sconify-version }} \
           ${{ steps.prepare-command.outputs.sconify-base-command }} \
-          --to=${{ steps.prepare-command.outputs.prod-image }} \
+          --to=${{ steps.prepare-command.outputs.image-repo }}:${{ steps.prepare-command.outputs.prod-image-tag }} \
           --scone-signer=/sig/enclave-key.pem
 
       - name: Push Prod Image
         if: ${{ inputs.sconify-prod }}
         id: push-prod
         run: |
-          docker push ${{ steps.prepare-command.outputs.prod-image }}
-          echo "image=${{ steps.prepare-command.outputs.prod-image }}" >> "$GITHUB_OUTPUT"
-          echo "checksum=0x$(docker image inspect ${{ steps.prepare-command.outputs.prod-image }} | jq .[0].RepoDigests[0] | sed 's/"//g' | awk -F '@sha256:' '{print $2}')" >> "$GITHUB_OUTPUT"
-          echo "mrenclave=$(docker run --rm -e SCONE_HASH=1 ${{ steps.prepare-command.outputs.prod-image }})" >> "$GITHUB_OUTPUT"
+          docker push ${{ steps.prepare-command.outputs.image-repo }}:${{ steps.prepare-command.outputs.prod-image-tag }}
+          echo "tag=${{ steps.prepare-command.outputs.prod-image-tag }}" | tee -a "$GITHUB_OUTPUT"
+          echo "checksum=0x$(docker image inspect ${{ steps.prepare-command.outputs.image-repo }}:${{ steps.prepare-command.outputs.prod-image-tag }} | jq .[0].RepoDigests[0] | sed 's/"//g' | awk -F '@sha256:' '{print $2}')" | tee -a "$GITHUB_OUTPUT"
+          echo "mrenclave=$(docker run --rm -e SCONE_HASH=1 ${{ steps.prepare-command.outputs.image-repo }}:${{ steps.prepare-command.outputs.prod-image-tag }})" | tee -a "$GITHUB_OUTPUT"
 
       - name: Clean Temporary Directory
         if: always()

--- a/sconify/README.md
+++ b/sconify/README.md
@@ -59,10 +59,10 @@ The workflow performs the following actions:
 
 | **Output**          | **Description**                                                                    |
 | ------------------- | ---------------------------------------------------------------------------------- |
-| **debug-image**     | Debug Sconified Image (unless `inputs.sconify-debug: false`)                       |
+| **debug-image-tag** | Debug Sconified Image Tag (unless `inputs.sconify-debug: false`)                   |
 | **debug-mrenclave** | Debug Sconified Image MrEnclave Fingerprint (unless `inputs.sconify-debug: false`) |
 | **debug-checksum**  | Debug Sconified Image Checksum (unless `inputs.sconify-debug: false`)              |
-| **prod-image**      | Prod Sconified Image (unless `inputs.sconify-prod: false`)                         |
+| **prod-image-tag**  | Prod Sconified Image Tag (unless `inputs.sconify-prod: false`)                     |
 | **prod-mrenclave**  | Prod Sconified Image MrEnclave Fingerprint (unless `inputs.sconify-prod: false`)   |
 | **prod-checksum**   | Prod Sconified Image Checksum (unless `inputs.sconify-prod: false`)                |
 
@@ -127,8 +127,8 @@ jobs:
     needs: sconify
     steps:
       - run: |
-          echo "DEBUG IMAGE INFO: image=${{ needs.sconify.outputs.debug-image }} | checksum=${{ needs.sconify.outputs.debug-checksum }} | mrenclave=${{ needs.sconify.outputs.debug-mrenclave }}"
-          echo "PROD IMAGE INFO: image=${{ needs.sconify.outputs.prod-image }} | checksum=${{ needs.sconify.outputs.prod-checksum }} | mrenclave=${{ needs.sconify.outputs.prod-mrenclave }}"
+          echo "DEBUG IMAGE INFO: tag=${{ needs.sconify.outputs.debug-image-tag }} | checksum=${{ needs.sconify.outputs.debug-checksum }} | mrenclave=${{ needs.sconify.outputs.debug-mrenclave }}"
+          echo "PROD IMAGE INFO: tag=${{ needs.sconify.outputs.prod-image-tag }} | checksum=${{ needs.sconify.outputs.prod-checksum }} | mrenclave=${{ needs.sconify.outputs.prod-mrenclave }}"
 ```
 
 3. **Configure Secrets**  

--- a/sconify/README.md
+++ b/sconify/README.md
@@ -22,23 +22,22 @@ The workflow performs the following actions:
 
 ## Workflow Inputs 🛠️
 
-| **Input**             | **Description**                                                                                          | **Required** | **Default**                      |
-| --------------------- | -------------------------------------------------------------------------------------------------------- | ------------ | -------------------------------- |
-| **docker-registry**   | Docker registry of docker image to sconify                                                               | No           | docker.io                        |
-| **docker-username**   | Docker registry username                                                                                 | Yes          | -                                |
-| **image-name**        | Name of docker image to sconify                                                                          | Yes          | -                                |
-| **image-tag**         | Tag of docker image to sconify                                                                           | Yes          | -                                |
-| **scontain-username** | Scontain registry username                                                                               | Yes          | -                                |
-| **sconify-version**   | Version of the sconify image to use                                                                      | Yes          | -                                |
-| **binary**            | [SCONE] Path of the binary to use                                                                        | Yes          | -                                |
-| **command**           | [SCONE] Command to execute                                                                               | No           | ENTRYPOINT + CMD of native image |
-| **binary-fs**         | [SCONE] Embed the file system into the binary via Scone binary file system                               | No           | false                            |
-| **fs-dir**            | [SCONE] Path of directories to add to the binary file system (use multiline to add multiple directories) | No           | -                                |
-| **fs-file**           | [SCONE] Path of files to add to the binary file system (use multiline to add multiple files)             | No           | -                                |
-| **host-path**         | [SCONE] Host path, served directly from the host file system (use multiline to add multiple path)        | No           | -                                |
-| **heap**              | [SCONE] Enclave heap size                                                                                | No           | 1G                               |
-| **dlopen**            | [SCONE] Scone dlopen mode (0:disable; 1:enable)                                                          | No           | 0                                |
-| **mprotect**          | [SCONE] Scone mprotect mode (0:disable; 1:enable)                                                        | No           | 0                                |
+| **Input**           | **Description**                                                                                          | **Required** | **Default**                      |
+| ------------------- | -------------------------------------------------------------------------------------------------------- | ------------ | -------------------------------- |
+| **docker-registry** | Docker registry of docker image to sconify                                                               | No           | docker.io                        |
+| **docker-username** | Docker registry username                                                                                 | Yes          | -                                |
+| **image-name**      | Name of docker image to sconify                                                                          | Yes          | -                                |
+| **image-tag**       | Tag of docker image to sconify                                                                           | Yes          | -                                |
+| **sconify-version** | Version of the sconify image to use                                                                      | Yes          | -                                |
+| **binary**          | [SCONE] Path of the binary to use                                                                        | Yes          | -                                |
+| **command**         | [SCONE] Command to execute                                                                               | No           | ENTRYPOINT + CMD of native image |
+| **binary-fs**       | [SCONE] Embed the file system into the binary via Scone binary file system                               | No           | false                            |
+| **fs-dir**          | [SCONE] Path of directories to add to the binary file system (use multiline to add multiple directories) | No           | -                                |
+| **fs-file**         | [SCONE] Path of files to add to the binary file system (use multiline to add multiple files)             | No           | -                                |
+| **host-path**       | [SCONE] Host path, served directly from the host file system (use multiline to add multiple path)        | No           | -                                |
+| **heap**            | [SCONE] Enclave heap size                                                                                | No           | 1G                               |
+| **dlopen**          | [SCONE] Scone dlopen mode (0:disable; 1:enable)                                                          | No           | 0                                |
+| **mprotect**        | [SCONE] Scone mprotect mode (0:disable; 1:enable)                                                        | No           | 0                                |
 
 | **sconify-debug** | Create Scone debug image | No | true |
 | **sconify-prod** | Create Scone production image | No | true |
@@ -50,7 +49,9 @@ The workflow performs the following actions:
 
 | **Secret**            | **Description**                                 | **Required**                            |
 | --------------------- | ----------------------------------------------- | --------------------------------------- |
+| **docker-username**   | Docker registry username                        | yes                                     |
 | **docker-password**   | Docker Registry Password or Token               | Yes                                     |
+| **scontain-username** | Scontain registry username                      | Yes                                     |
 | **scontain-password** | Scontain Registry Password or Token             | Yes                                     |
 | **scone-signing-key** | Signing Key for Scone Production (PEM RSA-3072) | Yes unless `inputs.sconify-prod: false` |
 
@@ -113,9 +114,9 @@ jobs:
       heap: 1G
       dlopen: 1
       mprotect: 1
-      docker-username: ${{ vars.DOCKER_USERNAME }}
-      scontain-username: ${{ vars.SCONTAIN_USERNAME }}
     secrets:
+      docker-username: ${{ secrets.DOCKER_USERNAME }}
+      scontain-username: ${{ secrets.SCONTAIN_USERNAME }}
       docker-password: ${{ secrets.DOCKER_TOKEN }}
       scontain-password: ${{ secrets.SCONTAIN_TOKEN }}
       scone-signing-key: ${{ secrets.SCONE_SIGNING_KEY }}
@@ -130,22 +131,11 @@ jobs:
           echo "PROD IMAGE INFO: image=${{ needs.sconify.outputs.prod-image }} | checksum=${{ needs.sconify.outputs.prod-checksum }} | mrenclave=${{ needs.sconify.outputs.prod-mrenclave }}"
 ```
 
-3. **Configure Variables**
-   Ensure that the following variables are added to your repository's settings:
-
-   - `DOCKER_USERNAME`: Your Docker Registry username
-   - `SCONTAIN_USERNAME`: Your Scontain username
-
-   NB: Beware if you choose to use secrets to store registries usernames;
-   registries usernames can appear in sconified image names outputted as `outputs.debug-image` and `outputs.prod-image`, in such a case GitHub Actions blanks the outputs with this waring:
-
-   > Skip output 'prod-image' since it may contain secret.
-
-   > Skip output 'debug-image' since it may contain secret.
-
-4. **Configure Secrets**  
+3. **Configure Secrets**  
    Ensure that the following secrets are added to your repository's settings:
+   - `DOCKER_USERNAME`: Your Docker Registry username
    - `DOCKER_PASSWORD`: Your Docker Registry password or access token
+   - `SCONTAIN_USERNAME`: Your Scontain username
    - `SCONTAIN_PASSWORD`: Your Scontain password or access token
    - `SCONE_SIGNING_KEY`: The key to use for signing Scone Prod applications
 

--- a/sconify/README.md
+++ b/sconify/README.md
@@ -95,7 +95,8 @@ on:
 
 jobs:
   sconify:
-    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/sconify.yml@sconify-v1.0.0
+    # ⚠️ use tagged version here
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/sconify.yml@main
     with:
       # runner: your-runner-here ⚠️ control the runner used in the workflow to match your requirements
       image-name: ${{ inputs.image-name }}


### PR DESCRIPTION
BREAKING

docker usernames are now secrets
image names is no longer output because it can contain secret (username), instead only tags are output

workflow test: https://github.com/PierreJeanjacquot/GA-tests/actions/runs/16197621644