### PR TITLE
feat(rust-build)!: enhance Rust workflow with linting and formatting

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -1,4 +1,4 @@
-name: Build and Test Rust Package
+name: Build, Test and Publish Rust Package
 
 on:
   workflow_call:
@@ -44,7 +44,6 @@ env:
   
 jobs:
   build:
-    name: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -98,21 +97,21 @@ jobs:
           path: ${{ inputs.artifact-path }}
 
   publish:
-      needs: build
-      if: ${{ inputs.publish-crates-io && needs.build.result == 'success' }}
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
+    needs: build
+    if: ${{ inputs.publish-crates-io && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-        - name: Install Rust toolchain
-          uses: dtolnay/rust-toolchain@stable
-          with:
-            toolchain: ${{ inputs.rust-version }}
-            components: cargo
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ inputs.rust-version }}
+          components: cargo
 
-        - name: Validate package
-          run: cargo package --allow-dirty
+      - name: Validate package
+        run: cargo package --allow-dirty
 
-        - name: Publish to crates.io
-          run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Publish to crates.io
+        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -7,10 +7,6 @@ on:
         description: 'The directory to run jobs from'
         default: '.'
         type: string
-      run-audit:
-        description: 'Run cargo-audit for security vulnerabilities'
-        default: true
-        type: boolean
       enable-cache:
         description: 'Enable caching of dependencies'
         default: true
@@ -19,18 +15,6 @@ on:
         description: 'Publish package to crates.io'
         default: false
         type: boolean
-      upload-artifact:
-        description: 'Upload build artifact'
-        default: false
-        type: boolean
-      artifact-name:
-        description: 'Name of the artifact to upload'
-        type: string
-        required: false
-      artifact-path:
-        description: 'Path to the artifact to upload'
-        type: string
-        required: false
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: false
@@ -69,15 +53,6 @@ jobs:
       - name: Run linter (Clippy)
         working-directory: ${{ inputs.working-directory }}
         run: cargo clippy --all-targets -- -D warnings
-      
-      - name: Install cargo-audit
-        if: ${{ inputs.run-audit }}
-        run: cargo install cargo-audit
-
-      - name: Run security audit
-        if: ${{ inputs.run-audit }}
-        working-directory: ${{ inputs.working-directory }}
-        run: cargo audit
 
       - name: Build
         working-directory: ${{ inputs.working-directory }}
@@ -86,13 +61,6 @@ jobs:
       - name: Run tests
         working-directory: ${{ inputs.working-directory }}
         run: cargo test --release
-
-      - name: Upload artifact
-        if: ${{ inputs.upload-artifact }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ inputs.artifact-name }}
-          path: ${{ inputs.artifact-path }}
 
       - name: Validate package
         if: ${{ inputs.publish-crates-io }}

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -43,6 +43,10 @@ on:
       CARGO_REGISTRY_TOKEN:
         required: false
 
+defaults:
+  run:
+    working-directory: ${{ inputs.working-directory }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -50,7 +54,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -105,7 +108,6 @@ jobs:
     needs: build
     if: ${{ inputs.publish-crates-io && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
-    working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -41,6 +41,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   
 jobs:
   build:
@@ -113,4 +114,4 @@ jobs:
         run: cargo package
 
       - name: Publish to crates.io
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -43,10 +43,6 @@ on:
       CARGO_REGISTRY_TOKEN:
         required: false
 
-defaults:
-  run:
-    working-directory: ${{ inputs.working-directory }}
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -78,9 +74,11 @@ jobs:
             ${{ runner.os }}-cargo-${{ inputs.build-target }}-
 
       - name: Check formatting
+        working-directory: ${{ inputs.working-directory }}
         run: cargo fmt --all -- --check
 
       - name: Run linter (Clippy)
+        working-directory: ${{ inputs.working-directory }}
         run: cargo clippy --all-targets -- -D warnings
       
       - name: Install cargo-audit
@@ -89,12 +87,15 @@ jobs:
 
       - name: Run security audit
         if: ${{ inputs.run-audit }}
+        working-directory: ${{ inputs.working-directory }}
         run: cargo audit
 
       - name: Build
+        working-directory: ${{ inputs.working-directory }}
         run: cargo build --profile ${{ inputs.build-target }}
 
       - name: Run tests
+        working-directory: ${{ inputs.working-directory }}
         run: cargo test --profile ${{ inputs.build-target }}
 
       - name: Upload artifact
@@ -119,7 +120,9 @@ jobs:
           components: cargo
 
       - name: Validate package
+        working-directory: ${{ inputs.working-directory }}
         run: cargo package
 
       - name: Publish to crates.io
+        working-directory: ${{ inputs.working-directory }}
         run: cargo publish

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -11,10 +11,6 @@ on:
         description: 'The directory to run jobs from'
         default: '.'
         type: string
-      run-audit:
-        description: 'Run cargo-audit for security vulnerabilities'
-        default: true
-        type: boolean
       enable-cache:
         description: 'Enable caching of dependencies'
         default: true
@@ -23,18 +19,6 @@ on:
         description: 'Publish package to crates.io'
         default: false
         type: boolean
-      upload-artifact:
-        description: 'Upload build artifact'
-        default: false
-        type: boolean
-      artifact-name:
-        description: 'Name of the artifact to upload'
-        type: string
-        required: false
-      artifact-path:
-        description: 'Path to the artifact to upload'
-        type: string
-        required: false
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: false
@@ -76,15 +60,6 @@ jobs:
       - name: Run linter (Clippy)
         working-directory: ${{ inputs.working-directory }}
         run: cargo clippy --all-targets -- -D warnings
-      
-      - name: Install cargo-audit
-        if: ${{ inputs.run-audit }}
-        run: cargo install cargo-audit
-
-      - name: Run security audit
-        if: ${{ inputs.run-audit }}
-        working-directory: ${{ inputs.working-directory }}
-        run: cargo audit
 
       - name: Build
         working-directory: ${{ inputs.working-directory }}
@@ -93,13 +68,6 @@ jobs:
       - name: Run tests
         working-directory: ${{ inputs.working-directory }}
         run: cargo test --release
-
-      - name: Upload artifact
-        if: ${{ inputs.upload-artifact }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ inputs.artifact-name }}
-          path: ${{ inputs.artifact-path }}
 
       - name: Validate package
         if: ${{ inputs.publish-crates-io }}

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -7,6 +7,10 @@ on:
         description: 'The directory to run jobs from'
         default: '.'
         type: string
+      run-audit:
+        description: 'Run cargo-audit for security vulnerabilities'
+        default: true
+        type: boolean
       enable-cache:
         description: 'Enable caching of dependencies'
         default: true
@@ -15,6 +19,18 @@ on:
         description: 'Publish package to crates.io'
         default: false
         type: boolean
+      upload-artifact:
+        description: 'Upload build artifact'
+        default: false
+        type: boolean
+      artifact-name:
+        description: 'Name of the artifact to upload'
+        type: string
+        required: false
+      artifact-path:
+        description: 'Path to the artifact to upload'
+        type: string
+        required: false
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: false
@@ -53,6 +69,15 @@ jobs:
       - name: Run linter (Clippy)
         working-directory: ${{ inputs.working-directory }}
         run: cargo clippy --all-targets -- -D warnings
+      
+      - name: Install cargo-audit
+        if: ${{ inputs.run-audit }}
+        run: cargo install cargo-audit
+
+      - name: Run security audit
+        if: ${{ inputs.run-audit }}
+        working-directory: ${{ inputs.working-directory }}
+        run: cargo audit
 
       - name: Build
         working-directory: ${{ inputs.working-directory }}
@@ -61,6 +86,13 @@ jobs:
       - name: Run tests
         working-directory: ${{ inputs.working-directory }}
         run: cargo test --release
+
+      - name: Upload artifact
+        if: ${{ inputs.upload-artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
 
       - name: Validate package
         if: ${{ inputs.publish-crates-io }}

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -11,6 +11,10 @@ on:
         description: 'Cargo profile to use for building (debug, release)'
         default: 'release'
         type: string
+      working-directory:
+        description: 'The directory to run jobs from'
+        default: '.'
+        type: string
       run-audit:
         description: 'Run cargo-audit for security vulnerabilities'
         default: true
@@ -46,6 +50,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -100,6 +105,7 @@ jobs:
     needs: build
     if: ${{ inputs.publish-crates-io && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
+    working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@${{ inputs.rust-version }}
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ inputs.rust-version }}
           components: clippy, rustfmt

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -1,4 +1,4 @@
-name: Build, Test and Publish Rust Package
+name: Build and Test Rust Package
 
 on:
   workflow_call:
@@ -7,97 +7,66 @@ on:
         description: 'Rust version to use'
         default: 'stable'
         type: string
-      build-target:
+      build-profile:
         description: 'Cargo profile to use for building (debug, release)'
         default: 'release'
         type: string
+      run-audit:
+        description: 'Run cargo-audit for security vulnerabilities'
+        default: true
+        type: boolean
       enable-cache:
         description: 'Enable caching of dependencies'
         default: true
         type: boolean
-      publish-crates-io:
-        description: 'Publish package to crates.io'
-        default: false
-        type: boolean
-      upload-artifact:
-        description: 'Upload build artifact'
-        default: false
-        type: boolean
-      artifact-name:
-        description: 'Name of the artifact to upload'
-        type: string
-        required: false
-      artifact-path:
-        description: 'Path to the artifact to upload'
-        type: string
-        required: false
-    secrets:
-      CRATES_IO_TOKEN:
-        required: false
 
+env:
+  CARGO_TERM_COLOR: always
+  
 jobs:
-  build:
+  build-and-test:
+    name: Build & Test
     runs-on: ubuntu-latest
-    outputs:
-      build_success: ${{ steps.set-output.outputs.build_success }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: ${{ inputs.rust-version }}
-          override: true
+          components: clippy
 
       - name: Cache dependencies
         if: ${{ inputs.enable-cache }}
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ inputs.build-profile }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ inputs.build-profile }}-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run linter (Clippy)
+        run: cargo clippy --all-targets -- -D warnings
+      
+      - name: Install cargo-audit
+        if: ${{ inputs.run-audit }}
+        run: cargo install cargo-audit
+
+      - name: Run security audit
+        if: ${{ inputs.run-audit }}
+        run: cargo audit
 
       - name: Build
-        run: cargo build --profile ${{ inputs.build-target }}
+        run: cargo build --profile ${{ inputs.build-profile }}
 
       - name: Run tests
-        run: cargo test --profile ${{ inputs.build-target }}
-
-      - name: Set build success output
-        id: set-output
-        run: echo "build_success=true" >> $GITHUB_OUTPUT
-
-      - name: Upload artifact
-        if: ${{ inputs.upload-artifact }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ inputs.artifact-name }}
-          path: ${{ inputs.artifact-path }}
-
-  publish:
-    needs: build
-    if: ${{ inputs.publish-crates-io && needs.build.outputs.build_success == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ inputs.rust-version }}
-          override: true
-
-      - name: Login to crates.io
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-
-      - name: Package for crates.io
-        run: cargo package
-
-      - name: Publish to crates.io
-        run: cargo publish
+        run: cargo test --profile ${{ inputs.build-profile }}

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -3,6 +3,10 @@ name: Build, Test and Publish Rust Package
 on:
   workflow_call:
     inputs:
+      rust-version:
+        description: 'Rust version to use'
+        default: 'stable'
+        type: string
       working-directory:
         description: 'The directory to run jobs from'
         default: '.'
@@ -30,8 +34,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Add clippy and rustfmt
-        run: rustup component add clippy rustfmt
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ inputs.rust-version }}
+          components: clippy, rustfmt, cargo
 
       - name: Cache dependencies
         if: ${{ inputs.enable-cache }}

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -35,10 +35,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@${{ inputs.rust-version }}
         with:
           toolchain: ${{ inputs.rust-version }}
-          components: clippy, rustfmt, cargo
+          components: clippy, rustfmt
 
       - name: Cache dependencies
         if: ${{ inputs.enable-cache }}

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.rust-version }}
           components: clippy, rustfmt

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -19,13 +19,32 @@ on:
         description: 'Enable caching of dependencies'
         default: true
         type: boolean
+      publish-crates-io:
+        description: 'Publish package to crates.io'
+        default: false
+        type: boolean
+      upload-artifact:
+        description: 'Upload build artifact'
+        default: false
+        type: boolean
+      artifact-name:
+        description: 'Name of the artifact to upload'
+        type: string
+        required: false
+      artifact-path:
+        description: 'Path to the artifact to upload'
+        type: string
+        required: false
+    secrets:
+      CRATES_IO_TOKEN:
+        required: false
 
 env:
   CARGO_TERM_COLOR: always
   
 jobs:
-  build-and-test:
-    name: Build & Test
+  build:
+    name: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -70,3 +89,30 @@ jobs:
 
       - name: Run tests
         run: cargo test --profile ${{ inputs.build-profile }}
+
+      - name: Upload artifact
+        if: ${{ inputs.upload-artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
+
+  publish:
+      needs: build
+      if: ${{ inputs.publish-crates-io && needs.build.result == 'success' }}
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+
+        - name: Install Rust toolchain
+          uses: dtolnay/rust-toolchain@stable
+          with:
+            toolchain: ${{ inputs.rust-version }}
+            components: cargo
+
+        - name: Validate package
+          run: cargo package --allow-dirty
+
+        - name: Publish to crates.io
+          run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -3,10 +3,6 @@ name: Build, Test and Publish Rust Package
 on:
   workflow_call:
     inputs:
-      rust-version:
-        description: 'Rust version to use'
-        default: 'stable'
-        type: string
       working-directory:
         description: 'The directory to run jobs from'
         default: '.'
@@ -34,11 +30,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ inputs.rust-version }}
-          components: clippy, rustfmt, cargo
+      - name: Add clippy and rustfmt
+        run: rustup component add clippy rustfmt
 
       - name: Cache dependencies
         if: ${{ inputs.enable-cache }}

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -7,7 +7,7 @@ on:
         description: 'Rust version to use'
         default: 'stable'
         type: string
-      build-profile:
+      build-target:
         description: 'Cargo profile to use for building (debug, release)'
         default: 'release'
         type: string
@@ -36,7 +36,7 @@ on:
         type: string
         required: false
     secrets:
-      CRATES_IO_TOKEN:
+      CARGO_REGISTRY_TOKEN:
         required: false
 
 env:
@@ -61,13 +61,12 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
+            ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ inputs.build-profile }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ inputs.build-target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ inputs.build-profile }}-
+            ${{ runner.os }}-cargo-${{ inputs.build-target }}-
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -84,10 +83,10 @@ jobs:
         run: cargo audit
 
       - name: Build
-        run: cargo build --profile ${{ inputs.build-profile }}
+        run: cargo build --profile ${{ inputs.build-target }}
 
       - name: Run tests
-        run: cargo test --profile ${{ inputs.build-profile }}
+        run: cargo test --profile ${{ inputs.build-target }}
 
       - name: Upload artifact
         if: ${{ inputs.upload-artifact }}
@@ -111,7 +110,7 @@ jobs:
           components: cargo
 
       - name: Validate package
-        run: cargo package --allow-dirty
+        run: cargo package
 
       - name: Publish to crates.io
-        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -7,10 +7,6 @@ on:
         description: 'Rust version to use'
         default: 'stable'
         type: string
-      build-target:
-        description: 'Cargo profile to use for building (debug, release)'
-        default: 'release'
-        type: string
       working-directory:
         description: 'The directory to run jobs from'
         default: '.'
@@ -48,7 +44,7 @@ env:
   CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   
 jobs:
-  build:
+  build_and_publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -58,7 +54,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ inputs.rust-version }}
-          components: clippy, rustfmt
+          components: clippy, rustfmt, cargo
 
       - name: Cache dependencies
         if: ${{ inputs.enable-cache }}
@@ -69,9 +65,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ inputs.build-target }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ inputs.build-target }}-
+            ${{ runner.os }}-cargo-release-
 
       - name: Check formatting
         working-directory: ${{ inputs.working-directory }}
@@ -92,11 +88,11 @@ jobs:
 
       - name: Build
         working-directory: ${{ inputs.working-directory }}
-        run: cargo build --profile ${{ inputs.build-target }}
+        run: cargo build --release
 
       - name: Run tests
         working-directory: ${{ inputs.working-directory }}
-        run: cargo test --profile ${{ inputs.build-target }}
+        run: cargo test --release
 
       - name: Upload artifact
         if: ${{ inputs.upload-artifact }}
@@ -105,24 +101,12 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.artifact-path }}
 
-  publish:
-    needs: build
-    if: ${{ inputs.publish-crates-io && needs.build.result == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ inputs.rust-version }}
-          components: cargo
-
       - name: Validate package
+        if: ${{ inputs.publish-crates-io }}
         working-directory: ${{ inputs.working-directory }}
         run: cargo package
 
       - name: Publish to crates.io
+        if: ${{ inputs.publish-crates-io }}
         working-directory: ${{ inputs.working-directory }}
         run: cargo publish

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ inputs.rust-version }}
-          components: clippy
+          components: clippy, rustfmt
 
       - name: Cache dependencies
         if: ${{ inputs.enable-cache }}

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -9,6 +9,7 @@ A reusable GitHub Actions workflow for building, linting, testing, and auditing 
 - Check formatting with `cargo fmt`
 - Run security audits with `cargo audit`
 - Cache dependencies for faster builds
+- Set a working directory for monorepos
 - Upload build artifacts
 - Publish to crates.io
 
@@ -25,6 +26,7 @@ jobs:
     with:
       rust-version: 'stable'
       build-target: 'release'
+      working-directory: './my-crate'
       run-audit: true
       enable-cache: true
       upload-artifact: true
@@ -40,6 +42,7 @@ jobs:
 | ------------------- | ------------------------------------------------------------ | --------- | -------- |
 | `rust-version`      | Rust version to use                                          | `stable`  | No       |
 | `build-target`      | Cargo profile to use for building (`debug`, `release`, etc.) | `release` | No       |
+| `working-directory` | The directory to run jobs from                               | `.`       | No       |
 | `run-audit`         | Run `cargo audit` for security vulnerabilities               | `true`    | No       |
 | `enable-cache`      | Enable caching of dependencies                               | `true`    | No       |
 | `upload-artifact`   | Upload a build artifact after building                       | `false`   | No       |
@@ -61,6 +64,16 @@ jobs:
 jobs:
   build-and-test:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
+```
+
+### Specify a Working Directory
+
+```yaml
+jobs:
+  build-and-test:
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
+    with:
+      working-directory: './my-crate'
 ```
 
 ### Disable Security Audit

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -24,14 +24,14 @@ jobs:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       rust-version: 'stable'
-      build-profile: 'release'
+      build-target: 'release'
       run-audit: true
       enable-cache: true
       upload-artifact: true
       artifact-name: my-crate
       artifact-path: target/release/my-crate
     secrets:
-      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 ```
 
 ## Inputs
@@ -39,7 +39,7 @@ jobs:
 | Name                | Description                                                  | Default   | Required |
 | ------------------- | ------------------------------------------------------------ | --------- | -------- |
 | `rust-version`      | Rust version to use                                          | `stable`  | No       |
-| `build-profile`     | Cargo profile to use for building (`debug`, `release`, etc.) | `release` | No       |
+| `build-target`      | Cargo profile to use for building (`debug`, `release`, etc.) | `release` | No       |
 | `run-audit`         | Run `cargo audit` for security vulnerabilities               | `true`    | No       |
 | `enable-cache`      | Enable caching of dependencies                               | `true`    | No       |
 | `upload-artifact`   | Upload a build artifact after building                       | `false`   | No       |
@@ -49,9 +49,9 @@ jobs:
 
 ## Secrets
 
-| Name              | Description                             | Required                              |
-| ----------------- | --------------------------------------- | ------------------------------------- |
-| `CRATES_IO_TOKEN` | crates.io API token for `cargo publish` | Only if `publish-crates-io` is `true` |
+| Name                   | Description                             | Required                              |
+| -----------------------| --------------------------------------- | ------------------------------------- |
+| `CARGO_REGISTRY_TOKEN` | crates.io API token for `cargo publish` | Only if `publish-crates-io` is `true` |
 
 ## Examples
 
@@ -73,14 +73,14 @@ jobs:
       run-audit: false
 ```
 
-### Use Debug Profile
+### Use Debug Target
 
 ```yaml
 jobs:
   build-and-test:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
-      build-profile: 'debug'
+      build-target: 'debug'
 ```
 
 ### Upload Artifact After Build
@@ -95,7 +95,7 @@ jobs:
       artifact-path: target/release/my-crate
 ```
 
-### Publish to crates.io (requires CRATES_IO_TOKEN)
+### Publish to crates.io (requires CARGO_REGISTRY_TOKEN)
 
 ```yaml
 jobs:
@@ -104,5 +104,5 @@ jobs:
     with:
       publish-crates-io: true
     secrets:
-      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 ```

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -1,18 +1,15 @@
 # Rust Build Workflow
 
-A reusable GitHub Actions workflow for building, linting, testing, and auditing Rust packages, with optional artifact upload and crates.io publishing.
+A reusable GitHub Actions workflow for building, linting, testing, and publishing Rust packages, with optional dependency caching and working directory support.
 
 ## Features
 
 - Build and test Rust packages
 - Lint code using `clippy`
 - Check formatting with `cargo fmt`
-- Run security audits with `cargo audit`
 - Cache dependencies for faster builds
-- Set a working directory for monorepos
-- Upload build artifacts
+- Set a working directory (for monorepos or nested crates)
 - Publish to crates.io
-- All operations are performed in a single job (no redundant toolchain installs)
 
 ## Usage
 
@@ -27,11 +24,8 @@ jobs:
     with:
       rust-version: 'stable'
       working-directory: './my-crate'
-      run-audit: true
       enable-cache: true
-      upload-artifact: true
-      artifact-name: my-crate
-      artifact-path: target/release/my-crate
+      publish-crates-io: false
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 ```
@@ -42,11 +36,7 @@ jobs:
 | ------------------- | --------------------------------------------------------- | -------- | -------- |
 | `rust-version`      | Rust version to use                                       | `stable` | No       |
 | `working-directory` | The directory to run jobs from                            | `.`      | No       |
-| `run-audit`         | Run `cargo audit` for security vulnerabilities            | `true`   | No       |
 | `enable-cache`      | Enable caching of dependencies                            | `true`   | No       |
-| `upload-artifact`   | Upload a build artifact after building                    | `false`  | No       |
-| `artifact-name`     | Name of the artifact to upload                            | –        | No       |
-| `artifact-path`     | Path to the artifact to upload                            | –        | No       |
 | `publish-crates-io` | Publish the package to crates.io (only if build succeeds) | `false`  | No       |
 
 Note: All builds use the release profile by default. There is no build-target input anymore
@@ -75,28 +65,6 @@ jobs:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       working-directory: './my-crate'
-```
-
-### Disable Security Audit
-
-```yaml
-jobs:
-  build-and-test:
-    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
-    with:
-      run-audit: false
-```
-
-### Upload Artifact After Build
-
-```yaml
-jobs:
-  build-and-upload:
-    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
-    with:
-      upload-artifact: true
-      artifact-name: my-crate
-      artifact-path: target/release/my-crate
 ```
 
 ### Publish to crates.io (requires CARGO_REGISTRY_TOKEN)

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -1,18 +1,15 @@
 # Rust Build Workflow
 
-A reusable GitHub Actions workflow for building, linting, testing, and auditing Rust packages, with optional artifact upload and crates.io publishing.
+A reusable GitHub Actions workflow for building, linting, testing, and publishing Rust packages, with optional dependency caching and working directory support.
 
 ## Features
 
 - Build and test Rust packages
 - Lint code using `clippy`
 - Check formatting with `cargo fmt`
-- Run security audits with `cargo audit`
 - Cache dependencies for faster builds
-- Set a working directory for monorepos
-- Upload build artifacts
+- Set a working directory (for monorepos or nested crates)
 - Publish to crates.io
-- All operations are performed in a single job (no redundant toolchain installs)
 
 ## Usage
 
@@ -26,11 +23,8 @@ jobs:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       working-directory: './my-crate'
-      run-audit: true
       enable-cache: true
-      upload-artifact: true
-      artifact-name: my-crate
-      artifact-path: target/release/my-crate
+      publish-crates-io: false
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 ```
@@ -40,11 +34,7 @@ jobs:
 | Name                | Description                                               | Default  | Required |
 | ------------------- | --------------------------------------------------------- | -------- | -------- |
 | `working-directory` | The directory to run jobs from                            | `.`      | No       |
-| `run-audit`         | Run `cargo audit` for security vulnerabilities            | `true`   | No       |
 | `enable-cache`      | Enable caching of dependencies                            | `true`   | No       |
-| `upload-artifact`   | Upload a build artifact after building                    | `false`  | No       |
-| `artifact-name`     | Name of the artifact to upload                            | –        | No       |
-| `artifact-path`     | Path to the artifact to upload                            | –        | No       |
 | `publish-crates-io` | Publish the package to crates.io (only if build succeeds) | `false`  | No       |
 
 Note: All builds use the release profile by default. There is no build-target input anymore
@@ -73,28 +63,6 @@ jobs:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       working-directory: './my-crate'
-```
-
-### Disable Security Audit
-
-```yaml
-jobs:
-  build-and-test:
-    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
-    with:
-      run-audit: false
-```
-
-### Upload Artifact After Build
-
-```yaml
-jobs:
-  build-and-upload:
-    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
-    with:
-      upload-artifact: true
-      artifact-name: my-crate
-      artifact-path: target/release/my-crate
 ```
 
 ### Publish to crates.io (requires CARGO_REGISTRY_TOKEN)

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -1,15 +1,18 @@
 # Rust Build Workflow
 
-A reusable GitHub Actions workflow for building, linting, testing, and publishing Rust packages, with optional dependency caching and working directory support.
+A reusable GitHub Actions workflow for building, linting, testing, and auditing Rust packages, with optional artifact upload and crates.io publishing.
 
 ## Features
 
 - Build and test Rust packages
 - Lint code using `clippy`
 - Check formatting with `cargo fmt`
+- Run security audits with `cargo audit`
 - Cache dependencies for faster builds
-- Set a working directory (for monorepos or nested crates)
+- Set a working directory for monorepos
+- Upload build artifacts
 - Publish to crates.io
+- All operations are performed in a single job (no redundant toolchain installs)
 
 ## Usage
 
@@ -23,8 +26,11 @@ jobs:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       working-directory: './my-crate'
+      run-audit: true
       enable-cache: true
-      publish-crates-io: false
+      upload-artifact: true
+      artifact-name: my-crate
+      artifact-path: target/release/my-crate
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 ```
@@ -34,7 +40,11 @@ jobs:
 | Name                | Description                                               | Default  | Required |
 | ------------------- | --------------------------------------------------------- | -------- | -------- |
 | `working-directory` | The directory to run jobs from                            | `.`      | No       |
+| `run-audit`         | Run `cargo audit` for security vulnerabilities            | `true`   | No       |
 | `enable-cache`      | Enable caching of dependencies                            | `true`   | No       |
+| `upload-artifact`   | Upload a build artifact after building                    | `false`  | No       |
+| `artifact-name`     | Name of the artifact to upload                            | –        | No       |
+| `artifact-path`     | Path to the artifact to upload                            | –        | No       |
 | `publish-crates-io` | Publish the package to crates.io (only if build succeeds) | `false`  | No       |
 
 Note: All builds use the release profile by default. There is no build-target input anymore
@@ -63,6 +73,28 @@ jobs:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       working-directory: './my-crate'
+```
+
+### Disable Security Audit
+
+```yaml
+jobs:
+  build-and-test:
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
+    with:
+      run-audit: false
+```
+
+### Upload Artifact After Build
+
+```yaml
+jobs:
+  build-and-upload:
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
+    with:
+      upload-artifact: true
+      artifact-name: my-crate
+      artifact-path: target/release/my-crate
 ```
 
 ### Publish to crates.io (requires CARGO_REGISTRY_TOKEN)

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -12,6 +12,7 @@ A reusable GitHub Actions workflow for building, linting, testing, and auditing 
 - Set a working directory for monorepos
 - Upload build artifacts
 - Publish to crates.io
+- All operations are performed in a single job (no redundant toolchain installs)
 
 ## Usage
 
@@ -25,7 +26,6 @@ jobs:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       rust-version: 'stable'
-      build-target: 'release'
       working-directory: './my-crate'
       run-audit: true
       enable-cache: true
@@ -38,22 +38,23 @@ jobs:
 
 ## Inputs
 
-| Name                | Description                                                  | Default   | Required |
-| ------------------- | ------------------------------------------------------------ | --------- | -------- |
-| `rust-version`      | Rust version to use                                          | `stable`  | No       |
-| `build-target`      | Cargo profile to use for building (`debug`, `release`, etc.) | `release` | No       |
-| `working-directory` | The directory to run jobs from                               | `.`       | No       |
-| `run-audit`         | Run `cargo audit` for security vulnerabilities               | `true`    | No       |
-| `enable-cache`      | Enable caching of dependencies                               | `true`    | No       |
-| `upload-artifact`   | Upload a build artifact after building                       | `false`   | No       |
-| `artifact-name`     | Name of the artifact to upload                               | –         | No       |
-| `artifact-path`     | Path to the artifact to upload                               | –         | No       |
-| `publish-crates-io` | Publish the package to crates.io (only if build succeeds)    | `false`   | No       |
+| Name                | Description                                               | Default  | Required |
+| ------------------- | --------------------------------------------------------- | -------- | -------- |
+| `rust-version`      | Rust version to use                                       | `stable` | No       |
+| `working-directory` | The directory to run jobs from                            | `.`      | No       |
+| `run-audit`         | Run `cargo audit` for security vulnerabilities            | `true`   | No       |
+| `enable-cache`      | Enable caching of dependencies                            | `true`   | No       |
+| `upload-artifact`   | Upload a build artifact after building                    | `false`  | No       |
+| `artifact-name`     | Name of the artifact to upload                            | –        | No       |
+| `artifact-path`     | Path to the artifact to upload                            | –        | No       |
+| `publish-crates-io` | Publish the package to crates.io (only if build succeeds) | `false`  | No       |
+
+Note: All builds use the release profile by default. There is no build-target input anymore
 
 ## Secrets
 
 | Name                   | Description                             | Required                              |
-| -----------------------| --------------------------------------- | ------------------------------------- |
+| ---------------------- | --------------------------------------- | ------------------------------------- |
 | `CARGO_REGISTRY_TOKEN` | crates.io API token for `cargo publish` | Only if `publish-crates-io` is `true` |
 
 ## Examples
@@ -84,16 +85,6 @@ jobs:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       run-audit: false
-```
-
-### Use Debug Target
-
-```yaml
-jobs:
-  build-and-test:
-    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
-    with:
-      build-target: 'debug'
 ```
 
 ### Upload Artifact After Build

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -87,7 +87,7 @@ jobs:
 
 ```yaml
 jobs:
-  build-and-test:
+  build-and-upload:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       upload-artifact: true
@@ -99,7 +99,7 @@ jobs:
 
 ```yaml
 jobs:
-  build-and-test:
+  build-and-publish:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       publish-crates-io: true

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -22,7 +22,6 @@ jobs:
   build-and-test:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
-      rust-version: 'stable'
       working-directory: './my-crate'
       enable-cache: true
       publish-crates-io: false
@@ -34,7 +33,6 @@ jobs:
 
 | Name                | Description                                               | Default  | Required |
 | ------------------- | --------------------------------------------------------- | -------- | -------- |
-| `rust-version`      | Rust version to use                                       | `stable` | No       |
 | `working-directory` | The directory to run jobs from                            | `.`      | No       |
 | `enable-cache`      | Enable caching of dependencies                            | `true`   | No       |
 | `publish-crates-io` | Publish the package to crates.io (only if build succeeds) | `false`  | No       |

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -1,13 +1,14 @@
-# Rust Build Workflow
+# Rust Build and Test Workflow
 
-A reusable GitHub Actions workflow for building, testing, and publishing Rust packages.
+A reusable GitHub Actions workflow for building, linting, testing, and auditing Rust packages.
 
 ## Features
 
 - Build and test Rust packages
+- Lint code using clippy
+- Check formatting with cargo fmt
+- Run security audits with cargo audit
 - Cache dependencies for faster builds
-- Publish packages to crates.io
-- Upload build artifacts
 
 ## Usage
 
@@ -21,30 +22,19 @@ jobs:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       rust-version: 'stable'
-      build-target: 'release'
+      build-profile: 'release'
+      run-audit: true
       enable-cache: true
-      upload-artifact: true
-      artifact-name: 'my-rust-app'
-      artifact-path: 'target/release/my-app'
 ```
 
 ## Inputs
 
-| Name                | Description                                        | Default   | Required                            |
-|---------------------|----------------------------------------------------|-----------|-------------------------------------|
-| `rust-version`      | Rust version to use                                | `stable`  | No                                  |
-| `build-target`      | Cargo profile to use for building (debug, release) | `release` | No                                  |
-| `enable-cache`      | Enable caching of dependencies                     | `true`    | No                                  |
-| `publish-crates-io` | Publish package to crates.io                       | `false`   | No                                  |
-| `upload-artifact`   | Upload build artifact                              | `false`   | No                                  |
-| `artifact-name`     | Name of the artifact to upload                     | -         | Only if `upload-artifact` is `true` |
-| `artifact-path`     | Path to the artifact to upload                     | -         | Only if `upload-artifact` is `true` |
-
-## Secrets
-
-| Name              | Description                       | Required                              |
-|-------------------|-----------------------------------|---------------------------------------|
-| `CRATES_IO_TOKEN` | Token for publishing to crates.io | Only if `publish-crates-io` is `true` |
+| Name            | Description                                    | Default   | Required |
+| --------------- | ---------------------------------------------- | --------- | -------- |
+| `rust-version`  | Rust version to use                            | `stable`  | No       |
+| `build-profile` | Cargo profile to use (debug, release)          | `release` | No       |
+| `run-audit`     | Run `cargo audit` for security vulnerabilities | `true`    | No       |
+| `enable-cache`  | Enable caching of dependencies                 | `true`    | No       |
 
 ## Examples
 
@@ -56,26 +46,23 @@ jobs:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
 ```
 
-### Build, Test, and Upload Artifact
+### Disable Security Audit
 
 ```yaml
 jobs:
   build-and-test:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
-      upload-artifact: true
-      artifact-name: 'my-rust-app'
-      artifact-path: 'target/release/my-app'
+      run-audit: false
 ```
 
-### Build, Test, and Publish to crates.io
+### Use Debug Profile
 
 ```yaml
 jobs:
-  build-and-publish:
+  jobs:
+  build-and-test:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
-      publish-crates-io: true
-    secrets:
-      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      build-profile: 'debug'
 ```

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -22,6 +22,7 @@ jobs:
   build-and-test:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
+      rust-version: 'stable'
       working-directory: './my-crate'
       enable-cache: true
       publish-crates-io: false
@@ -33,6 +34,7 @@ jobs:
 
 | Name                | Description                                               | Default  | Required |
 | ------------------- | --------------------------------------------------------- | -------- | -------- |
+| `rust-version`      | Rust version to use                                       | `stable` | No       |
 | `working-directory` | The directory to run jobs from                            | `.`      | No       |
 | `enable-cache`      | Enable caching of dependencies                            | `true`   | No       |
 | `publish-crates-io` | Publish the package to crates.io (only if build succeeds) | `false`  | No       |

--- a/rust-build/README.md
+++ b/rust-build/README.md
@@ -1,14 +1,16 @@
-# Rust Build and Test Workflow
+# Rust Build Workflow
 
-A reusable GitHub Actions workflow for building, linting, testing, and auditing Rust packages.
+A reusable GitHub Actions workflow for building, linting, testing, and auditing Rust packages, with optional artifact upload and crates.io publishing.
 
 ## Features
 
 - Build and test Rust packages
-- Lint code using clippy
-- Check formatting with cargo fmt
-- Run security audits with cargo audit
+- Lint code using `clippy`
+- Check formatting with `cargo fmt`
+- Run security audits with `cargo audit`
 - Cache dependencies for faster builds
+- Upload build artifacts
+- Publish to crates.io
 
 ## Usage
 
@@ -25,16 +27,31 @@ jobs:
       build-profile: 'release'
       run-audit: true
       enable-cache: true
+      upload-artifact: true
+      artifact-name: my-crate
+      artifact-path: target/release/my-crate
+    secrets:
+      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 ```
 
 ## Inputs
 
-| Name            | Description                                    | Default   | Required |
-| --------------- | ---------------------------------------------- | --------- | -------- |
-| `rust-version`  | Rust version to use                            | `stable`  | No       |
-| `build-profile` | Cargo profile to use (debug, release)          | `release` | No       |
-| `run-audit`     | Run `cargo audit` for security vulnerabilities | `true`    | No       |
-| `enable-cache`  | Enable caching of dependencies                 | `true`    | No       |
+| Name                | Description                                                  | Default   | Required |
+| ------------------- | ------------------------------------------------------------ | --------- | -------- |
+| `rust-version`      | Rust version to use                                          | `stable`  | No       |
+| `build-profile`     | Cargo profile to use for building (`debug`, `release`, etc.) | `release` | No       |
+| `run-audit`         | Run `cargo audit` for security vulnerabilities               | `true`    | No       |
+| `enable-cache`      | Enable caching of dependencies                               | `true`    | No       |
+| `upload-artifact`   | Upload a build artifact after building                       | `false`   | No       |
+| `artifact-name`     | Name of the artifact to upload                               | –         | No       |
+| `artifact-path`     | Path to the artifact to upload                               | –         | No       |
+| `publish-crates-io` | Publish the package to crates.io (only if build succeeds)    | `false`   | No       |
+
+## Secrets
+
+| Name              | Description                             | Required                              |
+| ----------------- | --------------------------------------- | ------------------------------------- |
+| `CRATES_IO_TOKEN` | crates.io API token for `cargo publish` | Only if `publish-crates-io` is `true` |
 
 ## Examples
 
@@ -60,9 +77,32 @@ jobs:
 
 ```yaml
 jobs:
-  jobs:
   build-and-test:
     uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
     with:
       build-profile: 'debug'
+```
+
+### Upload Artifact After Build
+
+```yaml
+jobs:
+  build-and-test:
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
+    with:
+      upload-artifact: true
+      artifact-name: my-crate
+      artifact-path: target/release/my-crate
+```
+
+### Publish to crates.io (requires CRATES_IO_TOKEN)
+
+```yaml
+jobs:
+  build-and-test:
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/rust-build.yml@main
+    with:
+      publish-crates-io: true
+    secrets:
+      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 ```


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE

feat(rust-build)!: enhance Rust workflow with linting and formatting (#79)

BREAKING CHANGE: remove build-target workflow input to enforce use of release builds and remove artifact upload step

END_COMMIT_OVERRIDE