### PR TITLE
fix: do not push build attestation in docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -272,7 +272,7 @@ jobs:
         with:
           subject-name: ${{ inputs.image-name }}
           subject-digest: ${{ steps.checksum.outputs.digest }}
-          push-to-registry: true # Push attestation to registry
+          push-to-registry: false # Do not push attestation to registry
 
       - name: Cleanup files
         if: always()


### PR DESCRIPTION
This fix is due to an authentication limitation on docker-regis.